### PR TITLE
Fix convenience docker compose up and down scripts

### DIFF
--- a/devenv/scripts/docker_compose_down_all.py
+++ b/devenv/scripts/docker_compose_down_all.py
@@ -18,7 +18,9 @@ def main():
 
     print('\n')
     for path in map(lambda x: str(x.absolute()), docker_compose_paths):
-        compose_down(file=path)
+        process = compose_down(file=path)
+        out, err = process.communicate()
+        print(f'stdout: {out}\nstderr: {err}')
 
 
 main()

--- a/devenv/scripts/docker_compose_up_all.py
+++ b/devenv/scripts/docker_compose_up_all.py
@@ -18,12 +18,17 @@ def main():
 
     # NOTE: (mibui 2023-04-20) This will create an error response if the network already exists, but that is fine. We just want to ensure the network actually exists.
     print('\nCreating docker network: couch-potatoes-network')
-    create_network(network_name='couch-potatoes-network',
-                   network_driver='bridge')
+    try:
+        create_network(network_name='couch-potatoes-network',
+                       network_driver='bridge').wait()
+    except:
+        pass
 
-    print("\n")
+    print("\nStarting Docker composes...")
     for path in map(lambda x: str(x.absolute()), docker_compose_paths):
-        compose_up(file=path, build=True, detached=True)
+        process = compose_up(file=path, build=True, detached=True)
+        out, err = process.communicate()
+        print(f'stdout: {out}\nstderr: {err}')
 
 
 main()

--- a/devenv/scripts/script_lib/docker_commands.py
+++ b/devenv/scripts/script_lib/docker_commands.py
@@ -4,15 +4,15 @@ import subprocess
 def create_network(network_name: str, network_driver: str):
     command = ['docker', 'network', 'create',
                network_name, '--driver', network_driver]
-    subprocess.run(command, shell=True)
+    return subprocess.Popen(command, shell=False)
 
 
 def compose_up(file: str, detached: bool, build: bool):
     command = ['docker', 'compose', '-f', file, 'up',
                '-d' if detached else None, '--build' if build else None]
-    subprocess.run(command, text=True, shell=True, stdout=subprocess.PIPE)
+    return subprocess.Popen(command, text=True, shell=False, stdout=subprocess.PIPE)
 
 
 def compose_down(file: str):
     command = ['docker', 'compose', '-f', file, 'down']
-    subprocess.run(command, text=True, shell=True, stdout=subprocess.PIPE)
+    return subprocess.Popen(command, text=True, shell=False, stdout=subprocess.PIPE)

--- a/src/Services/MovieInformation/docker-compose.override.yaml
+++ b/src/Services/MovieInformation/docker-compose.override.yaml
@@ -1,5 +1,5 @@
 services:
-  movieinformation:
+  movie-information:
     env_file:
       - ./.env
     ports:


### PR DESCRIPTION
Can now run all docker-compose files by running the "compose-up.bat" and shutting them down by running the "compose-down" 