### PR TITLE
Setup Kong API Gateway for local development

### DIFF
--- a/devenv/couch-cli/internal/docker/compose.go
+++ b/devenv/couch-cli/internal/docker/compose.go
@@ -18,9 +18,10 @@ type Compose struct {
 }
 
 type ComposeService struct {
-	Build   ComposeBuild `yaml:"build"`
-	Ports   []string     `yaml:"ports"`
-	EnvFile []string     `yaml:"env_file"`
+	ContainerName string       `yaml:"container_name"`
+	Build         ComposeBuild `yaml:"build"`
+	Ports         []string     `yaml:"ports"`
+	EnvFile       []string     `yaml:"env_file"`
 }
 
 type ComposeBuild struct {
@@ -45,8 +46,9 @@ func NewComposeService(serviceName string, composeService ComposeService, networ
 
 func WriteComposeFile(serviceName string) error {
 	service := ComposeService{
-		Ports:   []string{"8080:80"},
-		EnvFile: []string{"./env"},
+		ContainerName: strings.ToLower(serviceName) + "-service",
+		Ports:         []string{"8080:80"},
+		EnvFile:       []string{"./env"},
 		Build: ComposeBuild{
 			Context:    ".",
 			DockerFile: "./Dockerfile",

--- a/devenv/couch-cli/internal/osutil/dotenv.go
+++ b/devenv/couch-cli/internal/osutil/dotenv.go
@@ -2,6 +2,7 @@ package osutil
 
 import (
 	"bufio"
+	"fmt"
 	"io/fs"
 	"io/ioutil"
 	"log"
@@ -63,6 +64,19 @@ func ApplyDotenv(dotenvFile string) error {
 				return err2
 			}
 		}
+	}
+
+	return nil
+}
+
+func WriteDotEnvFile(folderPath string) error {
+	filePath := fmt.Sprintf("%v/.env", folderPath)
+
+	emptyBytes := make([]byte, 0)
+
+	err := os.WriteFile(filePath, emptyBytes, 0644)
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/devenv/couch-cli/internal/service/create.go
+++ b/devenv/couch-cli/internal/service/create.go
@@ -67,12 +67,20 @@ func CreatNewService(name string) error {
 		}
 	}
 
+	log.Println("Creating docker-compose.yaml...")
 	err = docker.WriteComposeFile(name)
 	if err != nil {
 		return err
 	}
 
+	log.Println("Creating Dockerfile...")
 	err = docker.WriteDockerfile(name)
+	if err != nil {
+		return err
+	}
+
+	log.Println("Creating .env file...")
+	err = osutil.WriteDotEnvFile(currentDir)
 	if err != nil {
 		return err
 	}

--- a/src/Infrastructure/README.md
+++ b/src/Infrastructure/README.md
@@ -1,0 +1,8 @@
+```csharp
+# NOTE: (mibui 2023-05-20) This is meant for local development. For production we will probably use some offering from GCP since have credits for that.
+#                          Otherwise we could also setup a service on GCP that runs the Kong API Gateway image
+```
+
+Kong API Gateway listens on `port 8000`. It also exposes a admin service at `port 8001` where we can access different information about the routes we have configured, e.g. `GET http://localhost:8001/user-service/routes`
+
+For this to work properly we need to ensure a `.env` file exists in every service folder and that if you need a GCP Service Account Key, then you must setup a `volume` in the `docker-compose.yaml` of the service. 

--- a/src/Infrastructure/docker-compose.yaml
+++ b/src/Infrastructure/docker-compose.yaml
@@ -9,6 +9,24 @@ services:
       - ~/.docker-conf/rabbitmq/data/:/var/lib/rabbitmq/
       - ~/.docker-conf/rabbitmq/log/:/var/log/rabbitmq
 
+  kong-gateway:
+    image: kong:latest
+    container_name: kong-gateway
+    volumes:
+      - ./kong.yaml:/usr/local/kong/declarative/kong.yaml
+    environment:
+      - KONG_DATABASE=off
+      - KONG_DECLARATIVE_CONFIG=/usr/local/kong/declarative/kong.yaml
+      - KONG_PROXY_ACCESS_LOG=/dev/stdout
+      - KONG_ADMIN_ACCESS_LOG=/dev/stdout
+      - KONG_PROXY_ERROR_LOG=/dev/stderr
+      - KONG_ADMIN_ERROR_LOG=/dev/stderr
+      - KONG_ADMIN_LISTEN=0.0.0.0:8001, 0.0.0.0:8444 ssl
+    ports:
+      - "8000:8000"
+      - "8443:8443"
+      - "127.0.0.1:8001:8001"
+      - "127.0.0.1:8444:8444"
 networks:
   default:
     name: couch-potatoes-network

--- a/src/Infrastructure/kong.yaml
+++ b/src/Infrastructure/kong.yaml
@@ -1,0 +1,54 @@
+_format_version: "3.0"
+_transform: true
+
+# NOTE: (mibui 2023-05-20) This is the configuration for Kong API Gateway for local development
+#                          Kong listens on port 8000 and redirects to the different services based
+#                          on the configured paths.
+#                          Kong also has a admin service that listens on port 8001, where we can
+#                          access information about the different services that has been created
+
+services:
+    - name: user-service
+      url: http://user-service
+      routes:
+          - name: users
+            strip_path: false
+            paths:
+                - /couch-potatoes/api/v1/users
+
+          - name: reviews
+            strip_path: false
+            paths:
+                - /couch-potatoes/api/v1/reviews
+
+    - name: person-service
+      url: http://person-service
+      routes:
+          - name: persons
+            strip_path: false
+            paths:
+                - /couch-potatoes/api/v1/person
+
+    - name: movieinformation-service
+      url: http://movieinformation-service
+      routes:
+          - name: movie-collection
+            strip_path: false
+            paths:
+                - /couch-potatoes/api/v1/movie-collection
+          - name: movie-credits
+            strip_path: false
+            paths:
+                - /couch-potatoes/api/v1/movie-credits
+          - name: movie-details
+            strip_path: false
+            paths:
+                - /couch-potatoes/api/v1/movie-details
+
+    - name: metrics-service
+      url: http://metrics-service
+      routes:
+          - name: person-metrics
+            strip_path: false
+            paths:
+                - /api/v1/person_metrics

--- a/src/Services/Metrics/docker-compose.yaml
+++ b/src/Services/Metrics/docker-compose.yaml
@@ -1,5 +1,6 @@
 services:
   metrics:
+    container_name: metrics-service
     build:
       context: .
       dockerfile: ./Dockerfile

--- a/src/Services/MovieInformation/docker-compose.yaml
+++ b/src/Services/MovieInformation/docker-compose.yaml
@@ -1,6 +1,7 @@
 # start with docker compose up --build or use rider
 services:
   movieinformation:
+    container_name: movieinformation-service
     build:
       context: .
       dockerfile: ./Dockerfile

--- a/src/Services/Person/docker-compose.yaml
+++ b/src/Services/Person/docker-compose.yaml
@@ -1,5 +1,6 @@
 services:
   person:
+    container_name: person-service
     build:
       context: .
       dockerfile: ./Dockerfile

--- a/src/Services/User/docker-compose.yaml
+++ b/src/Services/User/docker-compose.yaml
@@ -1,12 +1,13 @@
 services:
   user:
+    container_name: user-service
     build:
       context: .
       dockerfile: ./Dockerfile
     ports:
-    - 8080:80
+      - 8080:80
     env_file:
-    - ./.env
+      - ./.env
 networks:
   default:
     name: couch-potatoes-network


### PR DESCRIPTION
Setup docker compose and gateway configuration for Kong API Gateway for local development. 
Enables our frontend only having to send requests to `http://localhost:8000/couch-potatoes/api/v1`

The API gateway is located under the `Infrastructure` project. 
This change is augmented by the `couch-cli compose up -d` command since we can now just run all compose files during develpoment and route every request to a single URL.

Kong API Gateway listens on `port 8000`. It also exposes a admin service at `port 8001` where we can access different information about the routes we have configured, e.g. `GET http://localhost:8001/user-service/routes`

For this to work properly we need to ensure a `.env` file exists in every service folder and that if you need a GCP Service Account Key, then you must setup a `volume` in the `docker-compose.yaml` of the service. 