### PR TITLE
API Gateway Bootstrapper

### DIFF
--- a/src/Infrastructure/Cloud/README.md
+++ b/src/Infrastructure/Cloud/README.md
@@ -28,6 +28,13 @@ $ gcloud auth application-default login
 
 # Usage
 
+## Before deploying
+To install the custom modules, e.g. `container-service` run: 
+
+```bash
+$ terraform get
+```
+
 ## See changes
 
 To preview changes before deploying run:

--- a/src/Infrastructure/Cloud/backend.tf
+++ b/src/Infrastructure/Cloud/backend.tf
@@ -1,0 +1,6 @@
+terraform {
+  backend "gcs" {
+    bucket = "couch-potatoes-sep6-bucket-tfstate"
+    prefix = "terraform/state"
+  }
+}

--- a/src/Infrastructure/gateway-bootstrapper/.gitignore
+++ b/src/Infrastructure/gateway-bootstrapper/.gitignore
@@ -1,0 +1,21 @@
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work

--- a/src/Infrastructure/gateway-bootstrapper/Dockerfile
+++ b/src/Infrastructure/gateway-bootstrapper/Dockerfile
@@ -1,0 +1,25 @@
+FROM golang:alpine3.17 as build
+
+WORKDIR /app
+COPY . /app
+
+RUN go build
+
+
+FROM kong:3.3.0-alpine as final
+
+USER root
+
+RUN mkdir -p -- /bootstrapper/kong/declarative
+
+COPY --from=build /app/gateway-bootstrapper /bootstrapper
+COPY --from=build /app/bootstrap.sh /bootstrap.sh
+COPY --from=build /app/services.json /bootstrapper/services.json
+
+RUN chmod +x /bootstrap.sh
+
+EXPOSE 8000
+EXPOSE 8001
+
+ENTRYPOINT ["/bootstrap.sh"]
+

--- a/src/Infrastructure/gateway-bootstrapper/README.md
+++ b/src/Infrastructure/gateway-bootstrapper/README.md
@@ -2,10 +2,12 @@
 Dynamically changes `kong.yaml` URLs during container startup based on environment variables.
 
 ```javascript
-// NOTE: (mibui 2023-05-24) We need to rebuild the image
-//                          everytime we add a new service
-//                          since it needs the services.json inside the image
-
+// NOTE: (mibui 2023-05-24) We need to rebuild the image everytime
+//                          we add a new service since it needs the
+//                          services.json inside the image. Furthermore
+//                          We need to ensure that no "URL" is empty for the kong.yaml
+//                          that gets created, i.e. every service we declare in services.json,
+//                          must have a corresponding GATEWAY_SERVICE_NAME environment variable set
 ```
 
 ## Configuration

--- a/src/Infrastructure/gateway-bootstrapper/README.md
+++ b/src/Infrastructure/gateway-bootstrapper/README.md
@@ -1,0 +1,16 @@
+# API Gateway Bootstrapper
+Dynamically changes `kong.yaml` URLs during container startup based on environment variables.
+
+```javascript
+// NOTE: (mibui 2023-05-24) We need to rebuild the image
+//                          everytime we add a new service
+//                          since it needs the services.json inside the image
+
+```
+
+## Configuration
+Services should be declared in the `services.json` file.
+
+To set the URL for a given service, when it starts up in a container, set an environment variable with the following naming convention: `GATEWAY_SERVICE_NAME`
+
+e.g. `GATEWAY_USER_SERVICE=http://some_url`

--- a/src/Infrastructure/gateway-bootstrapper/bootstrap.sh
+++ b/src/Infrastructure/gateway-bootstrapper/bootstrap.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+export KONG_DATABASE=off
+export KONG_DECLARATIVE_CONFIG=/bootstrapper/kong/declarative/kong.yaml
+export KONG_PROXY_ACCESS_LOG=/dev/stdout
+export KONG_ADMIN_ACCESS_LOG=/dev/stdout
+export KONG_PROXY_ERROR_LOG=/dev/stderr
+export KONG_ADMIN_LISTEN=0.0.0.0:8001
+
+echo Kong API Gateway starting with configuration:
+cat /bootstrapper/kong/declarative/kong.yaml
+
+./bootstrapper/gateway-bootstrapper && /docker-entrypoint.sh kong docker-start

--- a/src/Infrastructure/gateway-bootstrapper/go.mod
+++ b/src/Infrastructure/gateway-bootstrapper/go.mod
@@ -1,0 +1,5 @@
+module gateway-bootstrapper
+
+go 1.18
+
+require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/src/Infrastructure/gateway-bootstrapper/go.sum
+++ b/src/Infrastructure/gateway-bootstrapper/go.sum
@@ -1,0 +1,3 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/src/Infrastructure/gateway-bootstrapper/internal/bootstrap/bootstrap.go
+++ b/src/Infrastructure/gateway-bootstrapper/internal/bootstrap/bootstrap.go
@@ -1,0 +1,73 @@
+package bootstrap
+
+import (
+    "fmt"
+    "gateway-bootstrapper/internal/kong"
+    "gopkg.in/yaml.v3"
+    "log"
+    "os"
+    "strings"
+)
+
+func Gateway() error {
+    serviceConfig, err := kong.ReadServicesConfiguration("/bootstrapper/services.json")
+    if err != nil {
+        return err
+    }
+
+    log.Printf("Detected %v services: \n", len(serviceConfig.Services))
+    for i, service := range serviceConfig.Services {
+        log.Printf("Service %v: %v", i+1, service.Name)
+    }
+
+    kongFile := kong.Kong{
+        FormatVersion: "3.0",
+        Transform:     true,
+    }
+
+    kongServices := make([]kong.KongService, 0)
+
+    for _, service := range serviceConfig.Services {
+        kongRoutes := make([]kong.KongRoute, 0)
+        host := os.Getenv(serviceNameToEnvironmentVariableFormat(service.Name))
+
+        log.Printf("%v will be used as URL for service %v", host, service.Name)
+
+        for _, route := range service.Routes {
+            kongRoutes = append(kongRoutes, kong.KongRoute{
+                Name:  route.Name,
+                Paths: route.Paths,
+            })
+        }
+
+        kongService := kong.KongService{
+            Name:   service.Name,
+            URL:    host,
+            Routes: kongRoutes,
+        }
+        kongServices = append(kongServices, kongService)
+    }
+
+    kongFile.Services = kongServices
+
+    kongFileSerialized, err := yaml.Marshal(&kongFile)
+    if err != nil {
+        return err
+    }
+
+    log.Printf("Writing the following kong.yaml configuration:\n%s\n", kongFileSerialized)
+    err = kongFile.WriteKongFile("/bootstrapper/kong/declarative")
+    if err != nil {
+        return err
+    }
+    log.Println("Kong files has been created.")
+
+    return nil
+}
+
+func serviceNameToEnvironmentVariableFormat(s string) string {
+    sUpper := strings.ToUpper(s)
+    sSeparatorReplaced := strings.ReplaceAll(sUpper, "-", "_")
+    environmentVariableKey := fmt.Sprintf("GATEWAY_%v", sSeparatorReplaced)
+    return environmentVariableKey
+}

--- a/src/Infrastructure/gateway-bootstrapper/internal/kong/kongyaml.go
+++ b/src/Infrastructure/gateway-bootstrapper/internal/kong/kongyaml.go
@@ -1,0 +1,40 @@
+package kong
+
+import (
+    "fmt"
+    "gopkg.in/yaml.v3"
+    "io/ioutil"
+)
+
+type Kong struct {
+    FormatVersion string        `yaml:"_format_version"`
+    Transform     bool          `yaml:"_transform"`
+    Services      []KongService `yaml:"services"`
+}
+
+type KongService struct {
+    Name   string      `yaml:"name"`
+    URL    string      `yaml:"url"`
+    Routes []KongRoute `yaml:"routes"`
+}
+
+type KongRoute struct {
+    Name      string   `yaml:"name"`
+    StripPath bool     `yaml:"strip_path"`
+    Paths     []string `yaml:"paths"`
+}
+
+func (kong *Kong) WriteKongFile(folder string) error {
+
+    asYaml, err := yaml.Marshal(&kong)
+    if err != nil {
+        return err
+    }
+
+    err = ioutil.WriteFile(fmt.Sprintf("%v/kong.yaml", folder), asYaml, 0644)
+    if err != nil {
+        return err
+    }
+
+    return nil
+}

--- a/src/Infrastructure/gateway-bootstrapper/internal/kong/services.go
+++ b/src/Infrastructure/gateway-bootstrapper/internal/kong/services.go
@@ -1,0 +1,39 @@
+package kong
+
+import (
+    "encoding/json"
+    "io/ioutil"
+    "os"
+)
+
+type ServicesConfiguration struct {
+    Services []ServicesConfigurationService `json:services`
+}
+
+type ServicesConfigurationService struct {
+    Name   string                       `json:name`
+    Routes []ServicesConfigurationRoute `json:routes`
+}
+
+type ServicesConfigurationRoute struct {
+    Name  string   `json:name`
+    Paths []string `json:paths`
+}
+
+func ReadServicesConfiguration(file string) (*ServicesConfiguration, error) {
+    jsonFile, err := os.Open(file)
+    if err != nil {
+        return &ServicesConfiguration{}, err
+    }
+    defer jsonFile.Close()
+
+    bytes, err := ioutil.ReadAll(jsonFile)
+    var config ServicesConfiguration
+
+    err = json.Unmarshal(bytes, &config)
+    if err != nil {
+        return &ServicesConfiguration{}, err
+    }
+
+    return &config, nil
+}

--- a/src/Infrastructure/gateway-bootstrapper/main.go
+++ b/src/Infrastructure/gateway-bootstrapper/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+    "gateway-bootstrapper/internal/bootstrap"
+    "log"
+)
+
+func main() {
+    err := bootstrap.Gateway()
+    if err != nil {
+        log.Fatal(err)
+    }
+}

--- a/src/Infrastructure/gateway-bootstrapper/services.json
+++ b/src/Infrastructure/gateway-bootstrapper/services.json
@@ -1,0 +1,77 @@
+{
+  "services": [
+    {
+      "name": "user-service",
+      "routes": [
+        {
+          "name": "users",
+          "paths": [
+            "/couch-potatoes/api/v1/users"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "person-service",
+      "routes": [
+        {
+          "name": "persons",
+          "paths": [
+            "/couch-potatoes/api/v1/persons"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "movieinformation-service",
+      "routes": [
+        {
+          "name": "movie-collection",
+          "paths": [
+            "/couch-potatoes/api/v1/movie-collection"
+          ]
+        },
+        {
+          "name": "movie-credits",
+          "paths": [
+            "/couch-potatoes/api/v1/movie-credits"
+          ]
+        },
+        {
+          "name": "movie-details",
+          "paths": [
+            "/couch-potatoes/api/v1/movie-details"
+          ]
+        },
+        {
+          "name": "movie-recommendations",
+          "paths": [
+            "/couch-potatoes/api/v1/recommended-movies"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "metrics-service",
+      "routes": [
+        {
+          "name": "persons-metrics",
+          "paths": [
+            "/couch-potatoes/api/v1/person/metrics"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "search-service",
+      "routes": [
+        {
+          "name": "search",
+          "paths": [
+            "/couch-potatoes/api/v1/search/multi"
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This enables us to dynamically add deployed Cloud Run service URLs to our Kong API Gateway configuration. 

More info can be found in `src/Infrastructure/gateway-bootstrapper/README.md`

This has been achieved by creating a custom Kong image that contains a bootstraper that will generate the `kong.yaml` on container startup based on environment variables. E.g. if we want to set the URL for a service called 'user-service' in `kong.yaml`, then we set the environment variable `GATEWAY_USER_SERVICE=http://some_url`. 

I have tested this with Movie Information service and it works, but can be a bit slow due to cold startups
 (Request -> Gateway -> Gateway container spins up -> Route request to movie information -> Movieinformation container spins up -> Handle request -> Response)